### PR TITLE
Update description for Google Udacity course

### DIFF
--- a/src/pages/dig-in.mdx
+++ b/src/pages/dig-in.mdx
@@ -19,7 +19,7 @@ So when are you an accessibility professional? My answer is... _shrug_? Keep car
 
 ### Free
 
-- [Web Accessibility](https://www.udacity.com/course/web-accessibility--ud891): A free Udacity course created as a partnership between Google and AT&T.
+- [Web Accessibility](https://www.udacity.com/course/web-accessibility--ud891): A free Udacity course created by Google.
 
 ### With Subscription
 


### PR DESCRIPTION
Hey Amberley, I was just checking out the site after discovering it on [the State of JS report](https://2020.stateofjs.com/en-US/features/syntax/).

![image](https://user-images.githubusercontent.com/1066253/108632259-d66b5300-7422-11eb-9f7e-1082e60d35cc.png)

I updated the description for the Udacity course that Alice and I worked on. We didn't work with AT&T on it—maybe Udacity was showing AT&T's logo somewhere on the page to promote something else?